### PR TITLE
Explicitly installs markdownlint-cli

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install npm packages
-        run: npm install
+        run: npm install && npm install markdownlint-cli
       - name: Lint
         # Run Markdownlint on diffed MD files. Do not run if there are no diffs.
         run: git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint


### PR DESCRIPTION
The markdown linter was [able to run as a workflow](https://github.com/googleinterns/univiz/runs/915637605?check_suite_focus=true) with this change.