### PR TITLE
Introduces UnivizConfig and related Guice bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ buildNumber.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/java,maven,appengine
 node_modules/
+
+### End of generated config ###
+
+# Ignore config for API keys
+capstone/src/main/resources/univiz_config.json

--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -15,11 +15,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.6</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <version>1.7.4</version>
@@ -30,6 +25,11 @@
       <artifactId>auto-value-annotations</artifactId>
       <version>1.7.4</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -15,6 +15,23 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.7.4</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.7.4</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>29.0-jre</version>
@@ -34,6 +51,11 @@
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ryanharter.auto.value</groupId>
+      <artifactId>auto-value-gson-runtime</artifactId>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -65,6 +87,25 @@
           <!-- TODO(ccondit): set project ID. -->
           <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
           <deploy.version>1.0-SNAPSHOT</deploy.version>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgs>
+            <arg>-verbose</arg>
+            <arg>-Xlint:unchecked</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.ryanharter.auto.value</groupId>
+              <artifactId>auto-value-gson-factory</artifactId>
+              <version>1.3.0</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>  

--- a/capstone/src/main/java/com/google/univiz/config/UnivizConfig.java
+++ b/capstone/src/main/java/com/google/univiz/config/UnivizConfig.java
@@ -1,0 +1,15 @@
+package com.google.univiz.config;
+
+import com.google.auto.value.AutoValue;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+
+@AutoValue
+@GenerateTypeAdapter
+/** Contains configuration parameters for the Univiz application. */
+public abstract class UnivizConfig {
+  public abstract String scorecardApiKey();
+
+  static UnivizConfig create(String scorecardApiKey) {
+    return new AutoValue_UnivizConfig(scorecardApiKey);
+  }
+}

--- a/capstone/src/main/java/com/google/univiz/config/UnivizConfigModule.java
+++ b/capstone/src/main/java/com/google/univiz/config/UnivizConfigModule.java
@@ -1,0 +1,26 @@
+package com.google.univiz.config;
+
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/** Install to inject Univiz configuration into application classes. */
+public final class UnivizConfigModule extends AbstractModule {
+  @Provides
+  @Singleton
+  UnivizConfig provideUnivizConfig() {
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY).create();
+    try (InputStreamReader configReader =
+        new InputStreamReader(Resources.getResource("univiz_config.json").openStream())) {
+      return gson.fromJson(configReader, UnivizConfig.class);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to load UnivizConfig", e);
+    }
+  }
+}

--- a/capstone/src/test/java/com/google/univiz/config/UnivizConfigModuleTest.java
+++ b/capstone/src/test/java/com/google/univiz/config/UnivizConfigModuleTest.java
@@ -1,0 +1,26 @@
+package com.google.univiz.config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.Guice;
+import javax.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class UnivizConfigModuleTest {
+
+  @Inject private UnivizConfig univizConfig;
+
+  @Before
+  public void setup() {
+    Guice.createInjector(new UnivizConfigModule()).injectMembers(this);
+  }
+
+  @Test
+  public void scorecardApiKey_deserializes() {
+    assertThat(univizConfig.scorecardApiKey()).isEqualTo("scorecard_test_key");
+  }
+}

--- a/capstone/src/test/resources/univiz_config.json
+++ b/capstone/src/test/resources/univiz_config.json
@@ -1,0 +1,3 @@
+{
+  "scorecardApiKey":"scorecard_test_key"
+}


### PR DESCRIPTION
Adds `UnivizConfig` and related Guice bindings.

- Adds the production path to .gitignore.
- Leveraging Gson on an AutoValue coming from resources.
- Using [approved third party lib](http://g3doc/third_party/java_src/auto_value_gson/README) to perform the autovalue serialization.