### PR TITLE
Adds the Jasmine Maven Plugin to enable JS testing

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -58,6 +58,22 @@
     <finalName>capstone</finalName>
     <plugins>
       <plugin>
+        <groupId>com.github.searls</groupId>
+        <artifactId>jasmine-maven-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <id>jasmine</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <jsSrcDir>${project.basedir}/src/main/webapp/js</jsSrcDir>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>


### PR DESCRIPTION
* Plugin [source is here](https://github.com/searls/jasmine-maven-plugin) - Apache 2 so should be good to use.
  - Our js sources should live in `src/main/webapp/js`
  - Our js tests should live in `src/test/javascript`
  - `mvn test` invokes Jasmine tests and Java tests
  - Invoke `mvn jasmine:bdd` to iterate on jasmine tests locally.
* Overall Jasmine documentation is [here](https://jasmine.github.io/)
* Tested locally:
![image](https://user-images.githubusercontent.com/2066940/89061256-41cfc500-d319-11ea-97f3-9b8d00aa6e87.png)
