### PR TITLE
Fixes maven.yaml to run on every PR

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,11 +3,7 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Before - we'd only run Java CI checks on branches that were pulling into the main branch. But since we're using stacked PRs we actually want them to run on every PR - not for any specific branch.