### PR TITLE
simple map display

### DIFF
--- a/capstone/src/main/webapp/dashboard.html
+++ b/capstone/src/main/webapp/dashboard.html
@@ -3,14 +3,15 @@
   <head>
     <meta charset="UTF-8">
     <title>Dashboard</title>
-    <!-- TODO(biancamacias): revist url to add api key -->
-    <!-- TODO(biancamacias): reference style.css and script.js -->
+    <link rel="stylesheet" href="/style.css">
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDASlFIoCLcOLp3fp4DesSqcJpZed0QDFw"></script>
+    <script src="/js/maps.js/"></script>
   </head>
-  <body>
+  <body onload="createMap()">
     <div id="header">
       <h1>UniViz</h1>
     </div>
-    <div id="map">
+    <div id="map" >
     </div>
     <div id="colleges">
     </div>

--- a/capstone/src/main/webapp/dashboard.html
+++ b/capstone/src/main/webapp/dashboard.html
@@ -11,7 +11,7 @@
     <div id="header">
       <h1>UniViz</h1>
     </div>
-    <div id="map" >
+    <div id="map">
     </div>
     <div id="colleges">
     </div>

--- a/capstone/src/main/webapp/js/maps.js
+++ b/capstone/src/main/webapp/js/maps.js
@@ -1,10 +1,9 @@
 /**
- * createMap() just displays the map onto the dashboard.
- * All parameters for positioning are hardcoded.
+ * Displays the map onto the dashboard with hardcoded values.
+ * @returns {void}
  */
-
 function createMap() {
   const map = new google.maps.Map(
-    document.getElementById('map'),
-    {center: {lat: 34.052, lng: -118.245}, zoom: 10});
+      document.getElementById('map'),
+      {center: {lat: 34.052, lng: -118.245}, zoom: 10});
 }

--- a/capstone/src/main/webapp/js/maps.js
+++ b/capstone/src/main/webapp/js/maps.js
@@ -1,3 +1,8 @@
+/**
+ * createMap() just displays the map onto the dashboard.
+ * All parameters for positioning are hardcoded.
+ */
+
 function createMap() {
   const map = new google.maps.Map(
     document.getElementById('map'),

--- a/capstone/src/main/webapp/js/maps.js
+++ b/capstone/src/main/webapp/js/maps.js
@@ -1,0 +1,5 @@
+function createMap() {
+  const map = new google.maps.Map(
+    document.getElementById('map'),
+    {center: {lat: 34.052, lng: -118.245}, zoom: 10});
+}

--- a/capstone/src/main/webapp/js/maps.js
+++ b/capstone/src/main/webapp/js/maps.js
@@ -1,6 +1,6 @@
 /**
  * Displays the map onto the dashboard with hardcoded values.
- * @returns {void}
+ * @return {void}
  */
 function createMap() {
   const map = new google.maps.Map(

--- a/capstone/src/main/webapp/style.css
+++ b/capstone/src/main/webapp/style.css
@@ -6,5 +6,5 @@ body {
 #map {
   border: thin solid black;
   height: 500px;
-  width: 500px;
+  width: 100%;
 }

--- a/capstone/src/main/webapp/style.css
+++ b/capstone/src/main/webapp/style.css
@@ -2,3 +2,9 @@ body {
   background-color: white;
   margin: 0;
 }
+
+#map {
+  border: thin solid black;
+  height: 500px;
+  width: 500px;
+}


### PR DESCRIPTION
This PR creates and displays a map onto ```dashboard.html```. This helped visualize where the map would be on the webpage, and it helped test the API key. The center location is hardcoded, and the ```script src=``` reference is subject to change if we decide to combine all JS files. the ```onload``` in the ```<body>``` is also subject to change to include other functions other than ```createMap()```. 

the lint problems at the moment are that ```createMap()``` is not used and that the ```const map``` is not used.

This is what the dashboard looks like:

![image](https://user-images.githubusercontent.com/51244558/89468145-b5177380-d72b-11ea-9f3d-3f1a337ebf7c.png)
