### PR TITLE
Cleaning up unwanted data elements from ScorecardData.java class

### DIFF
--- a/capstone/src/main/java/com/google/univiz/scorecard/ScorecardData.java
+++ b/capstone/src/main/java/com/google/univiz/scorecard/ScorecardData.java
@@ -37,13 +37,6 @@ abstract class ScorecardData {
   @SerializedName("school.main_campus")
   abstract int flagMainCampus();
 
-  /**
-   * Returns an integer from range [1, 8] that tells the degree of urbanization for institution's
-   * campus, from large city to rural.
-   */
-  @SerializedName("school.degree_urbanization")
-  abstract int urbanizationDegree();
-
   /** Returns a double representing the institution's latitude location measured in degrees. */
   @SerializedName("location.lat")
   abstract double latitude();

--- a/capstone/src/test/java/com/google/univiz/scorecard/ScorecardTest.java
+++ b/capstone/src/test/java/com/google/univiz/scorecard/ScorecardTest.java
@@ -18,10 +18,11 @@ public final class ScorecardTest {
    * JSON from scorecard.json comes directly from the CollegeScorecard API.
    * https://api.data.gov/ed/collegescorecard/v1/schools.json?school.name=New%20
    * York%20University&per_page=1&fields=id,school.name,school.city,school.main_
-   * campus,school.degree_urbanization,location.lat,location.lon,school.carnegie
-   * _size_setting,latest.admissions.admission_rate.overall,latest.admissions.sat
-   * _scores.average.overall,latest.student.size,latest.cost.attendance.academic_
-   * year,latest.student.demographics.men,latest.student.demographics.women&api_key=YOUR-API-KEY
+   * campus,location.lat,location.lon,school.carnegie_size_setting,
+   * latest.admissions.admission_rate.overall,
+   * latest.admissions.sat_scores.average.overall,latest.student.size,
+   * latest.cost.attendance.academic_year,latest.student.demographics.men,
+   * latest.student.demographics.women&api_key=YOUR-API-KEY
    */
   @Test
   public void testJsonDeserializes() throws Exception {
@@ -34,7 +35,6 @@ public final class ScorecardTest {
     assertThat(scorecardData.name()).isEqualTo("New York University");
     assertThat(scorecardData.city()).isEqualTo("New York");
     assertThat(scorecardData.flagMainCampus()).isEqualTo(1);
-    assertThat(scorecardData.urbanizationDegree()).isEqualTo(0);
     assertThat(scorecardData.latitude()).isEqualTo(40.729452);
     assertThat(scorecardData.longitude()).isEqualTo(-73.997264);
     assertThat(scorecardData.carnegieSizeDegree()).isEqualTo(17);

--- a/capstone/src/test/resources/com/google/univiz/scorecard/scorecard.json
+++ b/capstone/src/test/resources/com/google/univiz/scorecard/scorecard.json
@@ -11,6 +11,5 @@
   "latest.student.demographics.women":0.5747,
   "latest.student.size":26339,
   "id":193900,
-  "school.carnegie_size_setting":17,
-  "school.degree_urbanization":null
+  "school.carnegie_size_setting":17
 }


### PR DESCRIPTION
This PR is just to remove the data elements that won't be useful. I did a few calls on a handful of colleges and found that ```degreeUrbanization``` was coming up as `null` on every single college, so I decided to remove it, and we should make note not to include this in any REST requests in the future. 

If you find yourself doing a few tests yourself, and find that a data element is coming up `null` too often, we can just remove it to clean up the REST requests and make it easier for us to work with data that we **_know_** will be there instead of just resorting to defaults that say "unavailable" or "data not available."