### PR TITLE
Add fixing/replacing option to linters and formatters

### DIFF
--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -17,4 +17,4 @@ jobs:
           git config user.name "CSS Presubmit"
           git add .
           git commit -m "Format CSS files"
-          git push
+          git push origin `git rev-parse --abbrev-ref HEAD`

--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -17,5 +17,5 @@ jobs:
           git config user.name "CSS Presubmit"
           git add .
           if [ git commit -m "Format CSS files" ]; then
-            git push origin `git rev-parse --abbrev-ref HEAD`
+            git push origin `git branch --show-current`
           fi

--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -12,7 +12,7 @@ jobs:
         run: npm install
       - name: Lint
         # Run StyleLint on diffed CSS files. Do not run if there are no diffs.
-        run:
+        run: |
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint --fix
           git config user.name "CSS Presubmit"
           git add .

--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -14,6 +14,7 @@ jobs:
         # Run StyleLint on diffed CSS files. Do not run if there are no diffs.
         run:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint --fix
+          git config user.name "CSS Presubmit"
           git add .
           git commit -m "Format CSS files"
           git push

--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -12,4 +12,8 @@ jobs:
         run: npm install
       - name: Lint
         # Run StyleLint on diffed CSS files. Do not run if there are no diffs.
-        run: git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint
+        run:
+          git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint --fix
+          git add .
+          git commit -m "Format CSS files"
+          git push

--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -16,5 +16,6 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint --fix
           git config user.name "CSS Presubmit"
           git add .
-          git commit -m "Format CSS files"
-          git push origin `git rev-parse --abbrev-ref HEAD`
+          if [ git commit -m "Format CSS files" ]; then
+            git push origin `git rev-parse --abbrev-ref HEAD`
+          fi

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -17,4 +17,4 @@ jobs:
           git config user.name "JS Presubmit"
           git add .
           git commit -m "Format JS files"
-          git push
+          git push origin `git rev-parse --abbrev-ref HEAD`

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -17,5 +17,5 @@ jobs:
           git config user.name "JS Presubmit"
           git add .
           if [ git commit -m "Format JS files" ]; then
-            git push origin `git rev-parse --abbrev-ref HEAD`
+            git push origin `git branch --show-current`
           fi

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -12,4 +12,8 @@ jobs:
         run: npm install
       - name: Lint
         # Run ESLint on diffed JS files. Do not run if there are no diffs.
-        run: git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint
+        run:
+          git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint --fix
+          git add .
+          git commit -m "Format JS files"
+          git push

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -12,7 +12,7 @@ jobs:
         run: npm install
       - name: Lint
         # Run ESLint on diffed JS files. Do not run if there are no diffs.
-        run:
+        run: |
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint --fix
           git config user.name "JS Presubmit"
           git add .

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -16,5 +16,6 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint --fix
           git config user.name "JS Presubmit"
           git add .
-          git commit -m "Format JS files"
-          git push origin `git rev-parse --abbrev-ref HEAD`
+          if [ git commit -m "Format JS files" ]; then
+            git push origin `git rev-parse --abbrev-ref HEAD`
+          fi

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -14,6 +14,7 @@ jobs:
         # Run ESLint on diffed JS files. Do not run if there are no diffs.
         run:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint --fix
+          git config user.name "JS Presubmit"
           git add .
           git commit -m "Format JS files"
           git push

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -22,6 +22,7 @@ jobs:
             java -jar ./google-java-format-1.8-all-deps.jar $file > $file
             echo ""
           done
+          git config user.name "Java Presubmit"
           git add .
           git commit -m "Format java files"
           git push

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -26,5 +26,4 @@ jobs:
           git add .
           git commit -m "Format java files"
           git push origin `git rev-parse --abbrev-ref HEAD`
-          exit $EXIT
         shell: bash

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,10 +19,11 @@ jobs:
         run: |
           for file in $(git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
-              EXIT=1
-            fi
+            java -jar ./google-java-format-1.8-all-deps.jar $file > $file
             echo ""
           done
+          git add .
+          git commit -m "Format java files"
+          git push
           exit $EXIT
         shell: bash

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -25,6 +25,6 @@ jobs:
           git config user.name "Java Presubmit"
           git add .
           git commit -m "Format java files"
-          git push
+          git push origin `git rev-parse --abbrev-ref HEAD`
           exit $EXIT
         shell: bash

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -25,6 +25,6 @@ jobs:
           git config user.name "Java Presubmit"
           git add .
           if [ git commit -m "Format java files" ]; then
-            git push origin `git rev-parse --abbrev-ref HEAD`
+            git push origin `git branch --show-current`
           fi
         shell: bash

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -24,6 +24,7 @@ jobs:
           done
           git config user.name "Java Presubmit"
           git add .
-          git commit -m "Format java files"
-          git push origin `git rev-parse --abbrev-ref HEAD`
+          if [ git commit -m "Format java files" ]; then
+            git push origin `git rev-parse --abbrev-ref HEAD`
+          fi
         shell: bash

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            java -jar ./google-java-format-1.8-all-deps.jar $file > $file
+            java -jar ./google-java-format-1.8-all-deps.jar --replace $file
             echo ""
           done
           git config user.name "Java Presubmit"

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -17,4 +17,4 @@ jobs:
           git config user.name "Markdown Presubmit"
           git add .
           git commit -m "Format markdown files"
-          git push
+          git push origin `git rev-parse --abbrev-ref HEAD`

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -17,5 +17,5 @@ jobs:
           git config user.name "Markdown Presubmit"
           git add .
           if [ git commit -m "Format markdown files" ]; then
-            git push origin `git rev-parse --abbrev-ref HEAD`
+            git push origin `git branch --show-current`
           fi

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -16,5 +16,5 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint --fix
           git config user.name "Markdown Presubmit"
           git add .
-          git commit -m "Format markdown files"
-          git push origin `git rev-parse --abbrev-ref HEAD`
+          if [ git commit -m "Format markdown files" ]; then
+            git push origin `git rev-parse --abbrev-ref HEAD`

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -18,3 +18,4 @@ jobs:
           git add .
           if [ git commit -m "Format markdown files" ]; then
             git push origin `git rev-parse --abbrev-ref HEAD`
+          fi

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -12,4 +12,8 @@ jobs:
         run: npm install && npm install markdownlint-cli
       - name: Lint
         # Run Markdownlint on diffed MD files. Do not run if there are no diffs.
-        run: git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint
+        run:
+          git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint --fix
+          git add .
+          git commit -m "Format java files"
+          git push

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -12,7 +12,7 @@ jobs:
         run: npm install && npm install markdownlint-cli
       - name: Lint
         # Run Markdownlint on diffed MD files. Do not run if there are no diffs.
-        run:
+        run: |
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint --fix
           git config user.name "Markdown Presubmit"
           git add .

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -14,6 +14,7 @@ jobs:
         # Run Markdownlint on diffed MD files. Do not run if there are no diffs.
         run:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint --fix
+          git config user.name "Markdown Presubmit"
           git add .
-          git commit -m "Format java files"
+          git commit -m "Format markdown files"
           git push


### PR DESCRIPTION
I've had enough of manually running the formatters before committing, so I've added the `--fix` option to the JS/CSS/Markdown linters and added `--replace` to the Java formatter. Not only that the linters will commit the progress they made in reformatting the files, so for most things it should hopefully be very helpful.

I haven't really tested the modifications to the four linters much, aside from committing to this branch and making sure they behave properly when there are no diffs.