### PR TITLE
Test class with terrible formatting

### DIFF
--- a/.github/workflows/csslint.yaml
+++ b/.github/workflows/csslint.yaml
@@ -16,6 +16,6 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(css|htm|html)$" | xargs --no-run-if-empty npx stylelint --fix
           git config user.name "CSS Presubmit"
           git add .
-          if [ git commit -m "Format CSS files" ]; then
+          if ! git commit -m "Format CSS files" ; then
             git push origin `git branch --show-current`
           fi

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -16,6 +16,6 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(jsx|js)$" | xargs --no-run-if-empty npx eslint --fix
           git config user.name "JS Presubmit"
           git add .
-          if [ git commit -m "Format JS files" ]; then
+          if ! git commit -m "Format JS files" ; then
             git push origin `git branch --show-current`
           fi

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -24,7 +24,7 @@ jobs:
           done
           git config user.name "Java Presubmit"
           git add .
-          if [ git commit -m "Format java files" ]; then
+          if ! git commit -m "Format java files" ; then
             git push origin `git branch --show-current`
           fi
         shell: bash

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -16,6 +16,6 @@ jobs:
           git diff --diff-filter=ACM --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(md)$" | xargs --no-run-if-empty npx markdownlint --fix
           git config user.name "Markdown Presubmit"
           git add .
-          if [ git commit -m "Format markdown files" ]; then
+          if ! git commit -m "Format markdown files" ; then
             git push origin `git branch --show-current`
           fi

--- a/capstone/src/main/java/com/google/univiz/Dummy.java
+++ b/capstone/src/main/java/com/google/univiz/Dummy.java
@@ -1,0 +1,13 @@
+package com.google.univiz;
+
+import java.util.List;
+import java.util.ArrayList; // intentionally placed in non-alphabetical order
+
+public class Dummy {
+	// deep indentation of eight spaces instead of the regular two.
+	// At last, today is the day where I intentionally write over eighty-five characters in a line.
+	// I usually avoid doing that, but today it has to be done.
+
+	List<Integer> myList = new ArrayList<>();
+}
+

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -1,0 +1,10 @@
+function poorFormatting() {
+	// deep indent
+	//
+	//
+	//
+	var cool = 9;
+	let coolest = 88;
+	// looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongest line here
+}
+

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -1,10 +1,9 @@
+/**
+ */
 function poorFormatting() {
-	// deep indent
-	//
-	//
-	//
 	var cool = 9;
 	let coolest = 88;
-	// looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongest line here
+	console.log(cool);
+	console.log(coolest);
 }
-
+poorFormatting();


### PR DESCRIPTION
See if the Java formatting linter will auto commit a fix for the Dummy.java file.

The Dummy.java file should be changed to use two spaces instead of tabs, the imports should be alphabetized, the newline at the end of the file should be removed, and the long line should be broken up.