### PR TITLE
CollegeDataApi interface

### DIFF
--- a/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
+++ b/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
@@ -1,13 +1,11 @@
 package com.google.univiz;
 
 import java.util.List;
-import java.util.Set;
 
 /**
- * CollegeDataApi is an interface for the CollegeDataApiImpl class that interacts with external APIs
- * to send REST requests.
+ * Provides access to college related data.
  */
 public interface CollegeDataApi {
 
-  List<CollegeData> getCollegesById(Set<CollegeId> ids);
+  List<CollegeData> getCollegesById(List<CollegeId> ids);
 }

--- a/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
+++ b/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
@@ -2,9 +2,7 @@ package com.google.univiz;
 
 import java.util.List;
 
-/**
- * Provides access to college related data.
- */
+/** Provides access to college related data. */
 public interface CollegeDataApi {
 
   List<CollegeData> getCollegesById(List<CollegeId> ids);

--- a/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
+++ b/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
@@ -1,0 +1,9 @@
+package com.google.univiz;
+
+import java.util.List;
+import java.util.Set;
+
+public interface CollegeDataApi {
+
+  List<CollegeData> getCollegesById(Set<CollegeId> ids);
+}

--- a/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
+++ b/capstone/src/main/java/com/google/univiz/CollegeDataApi.java
@@ -3,6 +3,10 @@ package com.google.univiz;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * CollegeDataApi is an interface for the CollegeDataApiImpl class that interacts with external APIs
+ * to send REST requests.
+ */
 public interface CollegeDataApi {
 
   List<CollegeData> getCollegesById(Set<CollegeId> ids);


### PR DESCRIPTION
This is an interface for the `CollegeDataApiImpl.java` class, which is meant to be the only class that interacts with the CollegeScorecard API.

This interface has only one method, `getCollegesById`, which is meant to send the REST request into the backend and use the converter to convert from `ScorecardData` class to `CollegeData` class.