### PR TITLE
CollegeScorecardAPI "metadata" and "results" parser

### DIFF
--- a/capstone/src/main/java/com/google/univiz/scorecard/ScorecardResponse.java
+++ b/capstone/src/main/java/com/google/univiz/scorecard/ScorecardResponse.java
@@ -1,13 +1,19 @@
 package com.google.univiz.scorecard;
 
 import com.google.auto.value.AutoValue;
+import com.google.gson.annotations.SerializedName;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.List;
 
+/**
+ * ScorecardResponse is a class representing a list of ScorecardData types. This class parses the
+ * JSON by only taking the JSON data from the "results", which is the array that holds the
+ * college/university/institution data needed for the UniViz app.
+ */
 @GenerateTypeAdapter
 @AutoValue
 abstract class ScorecardResponse {
-  
-  @SeralizedName("results")
+
+  @SerializedName("results")
   abstract List<ScorecardData> scorecardData();
 }

--- a/capstone/src/main/java/com/google/univiz/scorecard/ScorecardResponse.java
+++ b/capstone/src/main/java/com/google/univiz/scorecard/ScorecardResponse.java
@@ -1,0 +1,13 @@
+package com.google.univiz.scorecard;
+
+import com.google.auto.value.AutoValue;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.util.List;
+
+@GenerateTypeAdapter
+@AutoValue
+abstract class ScorecardResponse {
+  
+  @SeralizedName("results")
+  abstract List<ScorecardData> scorecardData();
+}

--- a/capstone/src/test/java/com/google/univiz/scorecard/ScorecardResponseTest.java
+++ b/capstone/src/test/java/com/google/univiz/scorecard/ScorecardResponseTest.java
@@ -1,0 +1,46 @@
+package com.google.univiz.scorecard;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.io.InputStreamReader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ScorecardResponseTest {
+
+  /**
+   * JSON from scorecard.json comes directly from the CollegeScorecard API.
+   *
+   * @see <a
+   *     href="https://api.data.gov/ed/collegescorecard/v1/schools.json?school.name=New%20York%20University&per_page=1&fields=id,school.name,school.city,school.main_campus,location.lat,location.lon,school.carnegie_size_setting,latest.admissions.admission_rate.overall,latest.admissions.sat_scores.average.overall,latest.student.size,latest.cost.attendance.academic_year,latest.student.demographics.men,latest.student.demographics.women&api_key=YOUR-API-KEY">http://api.data.gov/ed/collegescorecard</a>
+   */
+  @Test
+  public void testJsonDeserializes() throws Exception {
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY).create();
+    InputStreamReader scorecardReader =
+        new InputStreamReader(
+            Resources.getResource(ScorecardResponseTest.class, "scorecard_response.json")
+                .openStream());
+    ScorecardResponse response = gson.fromJson(scorecardReader, ScorecardResponse.class);
+    ScorecardData scorecardData = response.scorecardData().get(0);
+
+    assertThat(scorecardData.name()).isEqualTo("New York University");
+    assertThat(scorecardData.city()).isEqualTo("New York");
+    assertThat(scorecardData.flagMainCampus()).isEqualTo(1);
+    assertThat(scorecardData.latitude()).isEqualTo(40.729452);
+    assertThat(scorecardData.longitude()).isEqualTo(-73.997264);
+    assertThat(scorecardData.carnegieSizeDegree()).isEqualTo(17);
+    assertThat(scorecardData.admissionRate()).isEqualTo(0.1999);
+    assertThat(scorecardData.avgSat()).isEqualTo(1419.0);
+    assertThat(scorecardData.numOfUndergrads()).isEqualTo(26339);
+    assertThat(scorecardData.avgCost()).isEqualTo(69830);
+    assertThat(scorecardData.ratioOfMen()).isEqualTo(0.4253);
+    assertThat(scorecardData.ratioOfWomen()).isEqualTo(0.5747);
+  }
+}

--- a/capstone/src/test/java/com/google/univiz/scorecard/ScorecardResponseTest.java
+++ b/capstone/src/test/java/com/google/univiz/scorecard/ScorecardResponseTest.java
@@ -28,19 +28,9 @@ public final class ScorecardResponseTest {
             Resources.getResource(ScorecardResponseTest.class, "scorecard_response.json")
                 .openStream());
     ScorecardResponse response = gson.fromJson(scorecardReader, ScorecardResponse.class);
+    assertThat(response.scorecardData()).hasSize(1);
     ScorecardData scorecardData = response.scorecardData().get(0);
 
     assertThat(scorecardData.name()).isEqualTo("New York University");
-    assertThat(scorecardData.city()).isEqualTo("New York");
-    assertThat(scorecardData.flagMainCampus()).isEqualTo(1);
-    assertThat(scorecardData.latitude()).isEqualTo(40.729452);
-    assertThat(scorecardData.longitude()).isEqualTo(-73.997264);
-    assertThat(scorecardData.carnegieSizeDegree()).isEqualTo(17);
-    assertThat(scorecardData.admissionRate()).isEqualTo(0.1999);
-    assertThat(scorecardData.avgSat()).isEqualTo(1419.0);
-    assertThat(scorecardData.numOfUndergrads()).isEqualTo(26339);
-    assertThat(scorecardData.avgCost()).isEqualTo(69830);
-    assertThat(scorecardData.ratioOfMen()).isEqualTo(0.4253);
-    assertThat(scorecardData.ratioOfWomen()).isEqualTo(0.5747);
   }
 }

--- a/capstone/src/test/resources/com/google/univiz/scorecard/scorecard_response.json
+++ b/capstone/src/test/resources/com/google/univiz/scorecard/scorecard_response.json
@@ -1,0 +1,23 @@
+{
+  "metadata": {
+    "total":40,
+    "page":0,
+    "per_page":1
+  },
+  "results": [
+    {
+      "latest.cost.attendance.academic_year":69830,
+      "location.lon":-73.997264,"school.main_campus":1,
+      "school.name":"New York University",
+      "latest.student.size":26339,
+      "latest.student.demographics.men":0.4253,
+      "latest.student.demographics.women":0.5747,
+      "school.city":"New York",
+      "location.lat":40.729452,
+      "latest.admissions.sat_scores.average.overall":1419.0,
+      "latest.admissions.admission_rate.overall":0.1999,
+      "id":193900,
+      "school.carnegie_size_setting":17
+    }
+  ]
+}


### PR DESCRIPTION
This PR includes the `ScorecardResponse.java` class, the `ScorecardResponseTest.java` class which tests to make sure the JSON is parsed correctly, and the `scorecard_response.json` file which holds the raw JSON provided when calling the CollegeScorecardAPI. The `ScorecardResponse.java` class only extracts the `results` array, which is the only information needed for the UniViz app. 

When coding the `CollegeDataApiImpl.java` class, the `ScorecardReponse.java` class will be used to parse the REST JSON response easily. The method will loop through the `scorecardData()` and convert each `ScorecardData` object to a `CollegeData` object.