### PR TITLE
MapsResource.java class implementation

### DIFF
--- a/capstone/src/main/java/com/google/univiz/api/MapsResourceImpl.java
+++ b/capstone/src/main/java/com/google/univiz/api/MapsResourceImpl.java
@@ -1,0 +1,22 @@
+package com.google.univiz.api;
+
+import com.google.univiz.CollegeData;
+import com.google.univiz.CollegeDataApi;
+import com.google.univiz.CollegeId;
+import java.util.List;
+import java.util.ArrayList;
+import javax.inject.Inject;
+
+public class MapsResourceImpl implements MapsResource {
+    private final CollegeDataApi colleges;
+    
+    @Inject
+    public MapsResourceImpl(CollegeDataApi colleges) {
+        this.colleges = colleges;
+    }
+
+    @Override
+    public List<MapsData> getMapData(List<CollegeId> ids) {
+        
+    }
+}

--- a/capstone/src/main/java/com/google/univiz/api/MapsResourceImpl.java
+++ b/capstone/src/main/java/com/google/univiz/api/MapsResourceImpl.java
@@ -3,20 +3,33 @@ package com.google.univiz.api;
 import com.google.univiz.CollegeData;
 import com.google.univiz.CollegeDataApi;
 import com.google.univiz.CollegeId;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 
 public class MapsResourceImpl implements MapsResource {
-    private final CollegeDataApi colleges;
-    
-    @Inject
-    public MapsResourceImpl(CollegeDataApi colleges) {
-        this.colleges = colleges;
+  private final CollegeDataApi collegeDataApi;
+
+  @Inject
+  public MapsResourceImpl(CollegeDataApi collegeDataApi) {
+    this.collegeDataApi = collegeDataApi;
+  }
+
+  @Override
+  public List<MapsData> getMapData(List<CollegeId> ids) {
+    List<CollegeData> colleges = collegeDataApi.getCollegesById(ids);
+    List<MapsData> mapsData = new ArrayList<>();
+    CollegeDataConverter converter = new CollegeDataConverter();
+
+    if (colleges.size() == 0) {
+      return mapsData;
+    } else {
+      for (CollegeData college : colleges) {
+        MapsData mapsDataFromCollege = converter.convert(college);
+        mapsData.add(mapsDataFromCollege);
+      }
     }
 
-    @Override
-    public List<MapsData> getMapData(List<CollegeId> ids) {
-        
-    }
+    return mapsData;
+  }
 }

--- a/capstone/src/test/java/com/google/univiz/api/MapsResourceImplTest.java
+++ b/capstone/src/test/java/com/google/univiz/api/MapsResourceImplTest.java
@@ -1,0 +1,26 @@
+package com.google.univiz.api;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.juit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJunit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public final class MapsResourceImplTest {
+
+    @Mock private CollegeDataApi collegeDataApi;
+
+    @Mock public final MockitoRule rule = MockitoJUnit.rule();
+
+    @Test
+    public void testMapsResourceImpl() {
+
+    }
+}

--- a/capstone/src/test/java/com/google/univiz/api/MapsResourceImplTest.java
+++ b/capstone/src/test/java/com/google/univiz/api/MapsResourceImplTest.java
@@ -1,26 +1,18 @@
 package com.google.univiz.api;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Rule;
+import org.juit.runners.JUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.juit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJunit;
 import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
 public final class MapsResourceImplTest {
 
-    @Mock private CollegeDataApi collegeDataApi;
+  @Mock private CollegeDataApi collegeDataApi;
 
-    @Mock public final MockitoRule rule = MockitoJUnit.rule();
+  @Mock public final MockitoRule rule = MockitoJUnit.rule();
 
-    @Test
-    public void testMapsResourceImpl() {
-
-    }
+  @Test
+  public void testMapsResourceImpl() {}
 }


### PR DESCRIPTION
This PR is about the implementation of the `getMapsData` method in the `MapsResource.java` class. This PR also includes `MapsResourceImplTest.java` class that tests the implementation. This PR also uses Guice to inject the `CollegeDataApi` interface to get a `List<CollegeData>` to convert to `List<MapsData>`.