### PR TITLE
Add Deadline visualization datatype

### DIFF
--- a/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
+++ b/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
@@ -1,6 +1,7 @@
 package com.google.univiz.api.representation;
 
 import com.google.auto.value.AutoValue;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 
 /**
  * Contains the date when applications are due for a particular college. Will be made serializable

--- a/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
+++ b/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
@@ -20,8 +20,6 @@ public abstract class Deadline {
 
   public abstract int closingYear();
 
-  public abstract String name();
-
   public static Builder builder() {
     return new AutoValue_Deadline.Builder();
   }

--- a/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
+++ b/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
@@ -7,6 +7,7 @@ import com.google.auto.value.AutoValue;
  * for the purpose of graphing due dates.
  */
 @AutoValue
+@GenerateTypeAdapter
 public abstract class Deadline {
   public abstract int openingMonth();
 

--- a/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
+++ b/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
@@ -2,6 +2,7 @@ package com.google.univiz.api.representation;
 
 import com.google.auto.value.AutoValue;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.time.LocalDate;
 
 /**
  * Contains the date when applications are due for a particular college. Will be made serializable
@@ -10,17 +11,9 @@ import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 @AutoValue
 @GenerateTypeAdapter
 public abstract class Deadline {
-  public abstract int openingMonth();
+  public abstract LocalDate openingDate();
 
-  public abstract int openingDay();
-
-  public abstract int openingYear();
-
-  public abstract int closingMonth();
-
-  public abstract int closingDay();
-
-  public abstract int closingYear();
+  public abstract LocalDate closingDate();
 
   public static Builder builder() {
     return new AutoValue_Deadline.Builder();
@@ -28,17 +21,9 @@ public abstract class Deadline {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setOpeningMonth(int value);
+    public abstract Builder setOpeningDate(LocalDate value);
 
-    public abstract Builder setOpeningDay(int value);
-
-    public abstract Builder setOpeningYear(int value);
-
-    public abstract Builder setClosingMonth(int value);
-
-    public abstract Builder setClosingDay(int value);
-
-    public abstract Builder setClosingYear(int value);
+    public abstract Builder setClosingDate(LocalDate value);
 
     public abstract Deadline build();
   }

--- a/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
+++ b/capstone/src/main/java/com/google/univiz/api/representation/Deadline.java
@@ -7,4 +7,39 @@ import com.google.auto.value.AutoValue;
  * for the purpose of graphing due dates.
  */
 @AutoValue
-public abstract class Deadline {}
+public abstract class Deadline {
+  public abstract int openingMonth();
+
+  public abstract int openingDay();
+
+  public abstract int openingYear();
+
+  public abstract int closingMonth();
+
+  public abstract int closingDay();
+
+  public abstract int closingYear();
+
+  public abstract String name();
+
+  public static Builder builder() {
+    return new AutoValue_Deadline.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setOpeningMonth(int value);
+
+    public abstract Builder setOpeningDay(int value);
+
+    public abstract Builder setOpeningYear(int value);
+
+    public abstract Builder setClosingMonth(int value);
+
+    public abstract Builder setClosingDay(int value);
+
+    public abstract Builder setClosingYear(int value);
+
+    public abstract Deadline build();
+  }
+}

--- a/capstone/src/main/java/com/google/univiz/api/resource/VisResourceImpl.java
+++ b/capstone/src/main/java/com/google/univiz/api/resource/VisResourceImpl.java
@@ -36,6 +36,15 @@ final class VisResourceImpl implements VisResource {
 
   @Override
   public List<Deadline> getDeadlines(List<CollegeId> colleges) {
-    throw new UnsupportedOperationException();
+    Deadline deadline =
+        Deadline.builder()
+            .setOpeningMonth(9)
+            .setOpeningDay(1)
+            .setOpeningYear(2020)
+            .setClosingMonth(12)
+            .setClosingDay(1)
+            .setClosingYear(2020)
+            .build();
+    return colleges.stream().map(college -> deadline).collect(toList());
   }
 }

--- a/capstone/src/main/java/com/google/univiz/api/resource/VisResourceImpl.java
+++ b/capstone/src/main/java/com/google/univiz/api/resource/VisResourceImpl.java
@@ -9,6 +9,8 @@ import com.google.univiz.api.representation.CollegeStats;
 import com.google.univiz.api.representation.Deadline;
 import com.google.univiz.api.representation.Timeline;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import javax.inject.Inject;
 
@@ -38,12 +40,8 @@ final class VisResourceImpl implements VisResource {
   public List<Deadline> getDeadlines(List<CollegeId> colleges) {
     Deadline deadline =
         Deadline.builder()
-            .setOpeningMonth(9)
-            .setOpeningDay(1)
-            .setOpeningYear(2020)
-            .setClosingMonth(12)
-            .setClosingDay(1)
-            .setClosingYear(2020)
+            .setOpeningDate(LocalDate.of(2020, Month.SEPTEMBER, 1))
+            .setClosingDate(LocalDate.of(2020, Month.DECEMBER, 1))
             .build();
     return colleges.stream().map(college -> deadline).collect(toList());
   }

--- a/capstone/src/main/java/com/google/univiz/servlets/CollegeDataVisualizationService.java
+++ b/capstone/src/main/java/com/google/univiz/servlets/CollegeDataVisualizationService.java
@@ -51,7 +51,7 @@ public final class CollegeDataVisualizationService extends HttpServlet {
             .collect(toList());
     List<? extends Object> response;
     if (req.getServletPath().endsWith(DEADLINES_SUFFIX)) {
-      throw new UnsupportedOperationException();
+      response = visResource.getDeadlines(collegeIds);
     } else if (req.getServletPath().endsWith(STATS_SUFFIX)) {
       response = visResource.getCollegeStats(collegeIds);
     } else if (req.getServletPath().endsWith(TIMELINES_SUFFIX)) {

--- a/capstone/src/test/java/com/google/univiz/api/resource/VisResourceImplTest.java
+++ b/capstone/src/test/java/com/google/univiz/api/resource/VisResourceImplTest.java
@@ -15,6 +15,8 @@ import com.google.univiz.api.representation.CollegeStats;
 import com.google.univiz.api.representation.Deadline;
 import com.google.univiz.common.MockCollegeData;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -105,12 +107,8 @@ public final class VisResourceImplTest {
 
     Deadline expectedDeadline =
         Deadline.builder()
-            .setOpeningMonth(9)
-            .setOpeningDay(1)
-            .setOpeningYear(2020)
-            .setClosingMonth(12)
-            .setClosingDay(1)
-            .setClosingYear(2020)
+            .setOpeningDate(LocalDate.of(2020, Month.SEPTEMBER, 1))
+            .setClosingDate(LocalDate.of(2020, Month.DECEMBER, 1))
             .build();
 
     deadlines.stream().forEach(deadline -> assertThat(deadline).isEqualTo(expectedDeadline));

--- a/capstone/src/test/java/com/google/univiz/api/resource/VisResourceImplTest.java
+++ b/capstone/src/test/java/com/google/univiz/api/resource/VisResourceImplTest.java
@@ -12,6 +12,7 @@ import com.google.univiz.api.CollegeDataApi;
 import com.google.univiz.api.representation.CollegeData;
 import com.google.univiz.api.representation.CollegeId;
 import com.google.univiz.api.representation.CollegeStats;
+import com.google.univiz.api.representation.Deadline;
 import com.google.univiz.common.MockCollegeData;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -95,9 +96,23 @@ public final class VisResourceImplTest {
   }
 
   @Test
-  public void testGetDeadlinesUnsupported() {
+  public void testGetDeadlines() {
     List<CollegeId> ids = Lists.newArrayList(NYU_COLLEGE_DATA.id(), STANFORD_COLLEGE_DATA.id());
 
-    assertThrows(UnsupportedOperationException.class, () -> visImpl.getDeadlines(ids));
+    List<Deadline> deadlines = visImpl.getDeadlines(ids);
+
+    assertThat(deadlines).hasSize(ids.size());
+
+    Deadline expectedDeadline =
+        Deadline.builder()
+            .setOpeningMonth(9)
+            .setOpeningDay(1)
+            .setOpeningYear(2020)
+            .setClosingMonth(12)
+            .setClosingDay(1)
+            .setClosingYear(2020)
+            .build();
+
+    deadlines.stream().forEach(deadline -> assertThat(deadline).isEqualTo(expectedDeadline));
   }
 }

--- a/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
@@ -16,6 +16,8 @@ import com.google.univiz.api.resource.VisResource;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.LocalDate;
+import java.time.Month;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -36,12 +38,8 @@ public final class CollegeDataVisualizationServiceTest {
 
   private static final Deadline DEADLINE =
       Deadline.builder()
-          .setOpeningMonth(9)
-          .setOpeningDay(1)
-          .setOpeningYear(2020)
-          .setClosingMonth(12)
-          .setClosingDay(1)
-          .setClosingYear(2020)
+          .setOpeningDate(LocalDate.of(2020, Month.SEPTEMBER, 1))
+          .setClosingDate(LocalDate.of(2020, Month.DECEMBER, 1))
           .build();
 
   @Rule public final MockitoRule rule = MockitoJUnit.rule();
@@ -111,8 +109,8 @@ public final class CollegeDataVisualizationServiceTest {
 
     String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "1");
 
-    assertThat(response).contains("\"openingMonth\":9");
-    assertThat(response).contains("\"openingDay\":1");
+    assertThat(response).contains("\"month\":9");
+    assertThat(response).contains("\"day\":1");
   }
 
   @Test
@@ -122,8 +120,8 @@ public final class CollegeDataVisualizationServiceTest {
 
     String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "1,2");
 
-    assertThat(response).contains("\"openingMonth\":9");
-    assertThat(response).contains("\"openingDay\":1");
+    assertThat(response).contains("\"month\":9");
+    assertThat(response).contains("\"day\":1");
   }
 
   @Test

--- a/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
@@ -91,7 +91,32 @@ public final class CollegeDataVisualizationServiceTest {
   }
 
   @Test
-  public void getDeadlineResults_throws() throws Exception {
+  public void getDeadlineResults_emptyQuery() throws Exception {
+    String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "");
+
+    assertThat(response).contains("[]");
+  }
+
+  @Test
+  public void getDeadlineResults_nullQuery() throws Exception {
+    String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, null);
+
+    assertThat(response).contains("[]");
+  }
+
+  @Test
+  public void getDeadlineResults_singleResult() throws Exception {
+    when(visResource.getDeadlines(ImmutableList.of(CollegeId.create(1))))
+        .thenReturn(ImmutableList.of(DEADLINE));
+
+    String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "1");
+
+    assertThat(response).contains("\"openingMonth\":9");
+    assertThat(response).contains("\"openingDay\":1");
+  }
+
+  @Test
+  public void getDeadlineResults_multiResult() throws Exception {
     when(visResource.getDeadlines(ImmutableList.of(CollegeId.create(1), CollegeId.create(2))))
         .thenReturn(ImmutableList.of(DEADLINE, DEADLINE));
 

--- a/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
@@ -11,6 +11,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.univiz.api.representation.CollegeId;
 import com.google.univiz.api.representation.CollegeStats;
+import com.google.univiz.api.representation.Deadline;
 import com.google.univiz.api.resource.VisResource;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -32,6 +33,16 @@ public final class CollegeDataVisualizationServiceTest {
 
   private static final CollegeStats COLLEGE_STATS_1 = collegeStatsOf(1234);
   private static final CollegeStats COLLEGE_STATS_2 = collegeStatsOf(2345);
+
+  private static final Deadline DEADLINE =
+      Deadline.builder()
+          .setOpeningMonth(9)
+          .setOpeningDay(1)
+          .setOpeningYear(2020)
+          .setClosingMonth(12)
+          .setClosingDay(1)
+          .setClosingYear(2020)
+          .build();
 
   @Rule public final MockitoRule rule = MockitoJUnit.rule();
 
@@ -81,9 +92,13 @@ public final class CollegeDataVisualizationServiceTest {
 
   @Test
   public void getDeadlineResults_throws() throws Exception {
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "1"));
+    when(visResource.getDeadlines(ImmutableList.of(CollegeId.create(1), CollegeId.create(2))))
+        .thenReturn(ImmutableList.of(DEADLINE, DEADLINE));
+
+    String response = doGet("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX, "1,2");
+
+    assertThat(response).contains("\"openingMonth\":9");
+    assertThat(response).contains("\"openingDay\":1");
   }
 
   @Test


### PR DESCRIPTION
Move forward with #39 and #38 by defining the structure of the Deadline datatype, allowing for a heatmap of deadlines for the user's colleges to be added. The deadlines will be hardcoded as the College Scorecard API does not include this information.