### PR TITLE
Introduces MapsServlet

### DIFF
--- a/capstone/src/main/java/com/google/univiz/GuiceServletConfig.java
+++ b/capstone/src/main/java/com/google/univiz/GuiceServletConfig.java
@@ -5,6 +5,7 @@ import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.google.inject.servlet.ServletModule;
 import com.google.univiz.servlets.CollegeDataVisualizationService;
+import com.google.univiz.servlets.MapsService;
 
 /** Context listener to bootstap Guice based servlets. */
 public class GuiceServletConfig extends GuiceServletContextListener {
@@ -16,6 +17,7 @@ public class GuiceServletConfig extends GuiceServletContextListener {
         new ServletModule() {
           @Override
           protected void configureServlets() {
+            serve("/maps").with(MapsService.class);
             serve("/viz/" + CollegeDataVisualizationService.DEADLINES_SUFFIX)
                 .with(CollegeDataVisualizationService.class);
             serve("/viz/" + CollegeDataVisualizationService.STATS_SUFFIX)

--- a/capstone/src/main/java/com/google/univiz/servlets/CollegeDataVisualizationService.java
+++ b/capstone/src/main/java/com/google/univiz/servlets/CollegeDataVisualizationService.java
@@ -1,9 +1,5 @@
 package com.google.univiz.servlets;
 
-import static com.google.common.base.Strings.*;
-import static java.util.stream.Collectors.*;
-
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.univiz.api.representation.CollegeId;
@@ -24,8 +20,6 @@ public final class CollegeDataVisualizationService extends HttpServlet {
   public static final String STATS_SUFFIX = "stats";
   public static final String TIMELINES_SUFFIX = "timelines";
 
-  private static final String ID_PARAM = "id";
-
   private final VisResource visResource;
   private final Gson gson;
 
@@ -37,18 +31,7 @@ public final class CollegeDataVisualizationService extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    String idParam = req.getParameter(ID_PARAM);
-    if (isNullOrEmpty(idParam)) {
-      ServletHelper.writeJsonToResponse(gson, resp, ImmutableList.of());
-      return;
-    }
-    List<CollegeId> collegeIds =
-        Splitter.on(',')
-            .trimResults()
-            .splitToStream(idParam)
-            .map(Integer::parseInt)
-            .map(CollegeId::create)
-            .collect(toList());
+    List<CollegeId> collegeIds = CollegeIdParamParser.parseCollegeIds(req);
     List<? extends Object> response;
     if (req.getServletPath().endsWith(DEADLINES_SUFFIX)) {
       throw new UnsupportedOperationException();

--- a/capstone/src/main/java/com/google/univiz/servlets/CollegeIdParamParser.java
+++ b/capstone/src/main/java/com/google/univiz/servlets/CollegeIdParamParser.java
@@ -1,0 +1,31 @@
+package com.google.univiz.servlets;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.univiz.api.representation.CollegeId;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+final class CollegeIdParamParser {
+
+  @VisibleForTesting static final String ID_PARAM = "id";
+
+  static List<CollegeId> parseCollegeIds(HttpServletRequest req) {
+    String idParam = req.getParameter(ID_PARAM);
+    if (isNullOrEmpty(idParam)) {
+      return Lists.newArrayList();
+    }
+    return Splitter.on(',')
+        .trimResults()
+        .splitToStream(idParam)
+        .map(Integer::parseInt)
+        .map(CollegeId::create)
+        .collect(toList());
+  }
+
+  private CollegeIdParamParser() {}
+}

--- a/capstone/src/main/java/com/google/univiz/servlets/MapsService.java
+++ b/capstone/src/main/java/com/google/univiz/servlets/MapsService.java
@@ -1,6 +1,5 @@
 package com.google.univiz.servlets;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.univiz.api.representation.CollegeId;

--- a/capstone/src/main/java/com/google/univiz/servlets/MapsService.java
+++ b/capstone/src/main/java/com/google/univiz/servlets/MapsService.java
@@ -1,0 +1,36 @@
+package com.google.univiz.servlets;
+
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.univiz.api.representation.CollegeId;
+import com.google.univiz.api.resource.MapsResource;
+import com.google.univiz.common.ServletHelper;
+import java.io.IOException;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Singleton
+public final class MapsService extends HttpServlet {
+
+  private final MapsResource mapsResource;
+  private final Gson gson;
+
+  @Inject
+  MapsService(MapsResource mapsResource, Gson gson) {
+    this.mapsResource = mapsResource;
+    this.gson = gson;
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    List<CollegeId> collegeIds = CollegeIdParamParser.parseCollegeIds(req);
+    List<? extends Object> response = mapsResource.getMapsData(collegeIds);
+
+    ServletHelper.writeJsonToResponse(gson, resp, ImmutableList.copyOf(response));
+  }
+}

--- a/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/CollegeDataVisualizationServiceTest.java
@@ -98,7 +98,7 @@ public final class CollegeDataVisualizationServiceTest {
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 
     when(mockRequest.getServletPath()).thenReturn(servletPath);
-    when(mockRequest.getParameter("id")).thenReturn(idString);
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn(idString);
     StringWriter stringWriter = new StringWriter();
     when(mockResponse.getWriter()).thenReturn(new PrintWriter(stringWriter));
 

--- a/capstone/src/test/java/com/google/univiz/servlets/CollegeIdParamParserTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/CollegeIdParamParserTest.java
@@ -1,0 +1,63 @@
+package com.google.univiz.servlets;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.univiz.api.representation.CollegeId;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public final class CollegeIdParamParserTest {
+
+  @Rule public final MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock private HttpServletRequest mockRequest;
+
+  @Test
+  public void nullQuery_emptyResults() {
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn(null);
+
+    List<CollegeId> response = CollegeIdParamParser.parseCollegeIds(mockRequest);
+
+    assertThat(response).isEmpty();
+  }
+
+  @Test
+  public void emptyQuery_emptyResults() {
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn("");
+
+    List<CollegeId> response = CollegeIdParamParser.parseCollegeIds(mockRequest);
+
+    assertThat(response).isEmpty();
+  }
+
+  @Test
+  public void singleId_singleResults() {
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn("1");
+
+    List<CollegeId> response = CollegeIdParamParser.parseCollegeIds(mockRequest);
+
+    assertThat(response).containsExactly(collegeIdOf(1));
+  }
+
+  @Test
+  public void multipleIds_multipleResults() {
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn("1,2");
+
+    List<CollegeId> response = CollegeIdParamParser.parseCollegeIds(mockRequest);
+
+    assertThat(response).containsExactly(collegeIdOf(1), collegeIdOf(2));
+  }
+
+  private static CollegeId collegeIdOf(int id) {
+    return CollegeId.create(id);
+  }
+}

--- a/capstone/src/test/java/com/google/univiz/servlets/MapsServiceTest.java
+++ b/capstone/src/test/java/com/google/univiz/servlets/MapsServiceTest.java
@@ -1,0 +1,103 @@
+package com.google.univiz.servlets;
+
+import static com.google.common.truth.Truth.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.univiz.api.representation.CollegeId;
+import com.google.univiz.api.representation.MapsData;
+import com.google.univiz.api.resource.MapsResource;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public final class MapsServiceTest {
+
+  private static final MapsData MAPS_DATA_1 = mapsDataOf("Stanford");
+  private static final MapsData MAPS_DATA_2 = mapsDataOf("NYU");
+
+  @Rule public final MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock @Bind private MapsResource mapsResource;
+
+  @Inject private MapsService mapsService;
+
+  @Before
+  public void setup() {
+    Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+  }
+
+  @Test
+  public void getMapsResults_emptyQuery() throws Exception {
+    String response = doGet("");
+
+    assertThat(response).isEqualTo("[]");
+  }
+
+  @Test
+  public void getMapsResults_nullQuery() throws Exception {
+    String response = doGet(null);
+
+    assertThat(response).isEqualTo("[]");
+  }
+
+  @Test
+  public void getMapsResults_singleResult() throws Exception {
+    when(mapsResource.getMapsData(ImmutableList.of(CollegeId.create(1))))
+        .thenReturn(ImmutableList.of(MAPS_DATA_1));
+
+    String response = doGet("1");
+
+    assertThat(response).contains("\"name\":\"Stanford\"");
+  }
+
+  @Test
+  public void getMapsResults_multiResult() throws Exception {
+    when(mapsResource.getMapsData(ImmutableList.of(CollegeId.create(1), CollegeId.create(2))))
+        .thenReturn(ImmutableList.of(MAPS_DATA_1, MAPS_DATA_2));
+
+    String response = doGet("1,2");
+
+    assertThat(response).contains("\"name\":\"Stanford\"");
+    assertThat(response).contains("\"name\":\"NYU\"");
+  }
+
+  private String doGet(String idString) throws IOException {
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+
+    when(mockRequest.getParameter(CollegeIdParamParser.ID_PARAM)).thenReturn(idString);
+    StringWriter stringWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(stringWriter));
+
+    mapsService.doGet(mockRequest, mockResponse);
+
+    return stringWriter.toString();
+  }
+
+  private static MapsData mapsDataOf(String name) {
+    return MapsData.builder()
+        .setName(name)
+        .setCity("city")
+        .setIsMainCampus(true)
+        .setLatitude(123.0)
+        .setLongitude(234.0)
+        .build();
+  }
+}


### PR DESCRIPTION
* Abstracts common logic into `CollegeIdParamParser`.
* Wires up "maps" as the resource path.

Tested locally:
![image](https://user-images.githubusercontent.com/2066940/91108683-79d2db00-e62d-11ea-8854-fb5cce2176b1.png)

