### PR TITLE
Fetch network resources only once

### DIFF
--- a/capstone/src/main/webapp/dashboard.html
+++ b/capstone/src/main/webapp/dashboard.html
@@ -21,7 +21,8 @@
     <div id="colleges">
     </div>
     <div id="data">
-      <div id="calendar-freq-map"></div>
+    </div>
+    <div id="calendar-freq-map">
     </div>
     <div id="admission-rate-data">
     </div>

--- a/capstone/src/main/webapp/js/demographicalGraphs.js
+++ b/capstone/src/main/webapp/js/demographicalGraphs.js
@@ -33,83 +33,23 @@ function graphDemographics() {
     new google.visualization.ColumnChart(
         document.getElementById('gender-ratio-data'),
     );
-  deserializeGenderRatioData().then(
-      (data) => genderRatioChart.draw(data, genderRatioOptions),
-  );
-  deserializeAdmissionData().then(
-      (data) => admissionRateChart.draw(data, admissionRateOptions),
-  );
-  deserializeAvgSatData().then(
-      (data) => avgSatChart.draw(data, avgSatOptions),
-  );
-  deserializeNumUndergradsData().then(
-      (data) => numUndergradsChart.draw(data, numUndergradsOptions),
-  );
-}
-
-/**
- * Helper function to fetch elements from JSON servlet.
- *
- * @return {google.visualization.DataTable} data the DataTable corresponding to
- *     the admission rate data
- */
-async function deserializeAdmissionData() {
-  const data = new google.visualization.DataTable();
-  await fetch('/viz/stats')
+  const admissionRateDataTable = new google.visualization.DataTable();
+  const numUndergradsDataTable = new google.visualization.DataTable();
+  const avgSatDataTable = new google.visualization.DataTable();
+  const genderRatioDataTable = new google.visualization.DataTable();
+  fetch('/viz/stats')
       .then((response) => response.json())
-      .then(
-          (admissionInfo) =>
-            populateAdmissionRateDataTable(data, admissionInfo),
-      );
-  return data;
-}
-
-/**
- * Helper function to fetch elements from JSON servlet.
- *
- * @return {google.visualization.DataTable} data the DataTable corresponding to
- *     the average SAT score data
- */
-async function deserializeAvgSatData() {
-  const data = new google.visualization.DataTable();
-  await fetch('/viz/stats')
-      .then((response) => response.json())
-      .then((avgSatInfo) => populateAvgSatDataTable(data, avgSatInfo));
-  return data;
-}
-
-/**
- * Helper function to fetch elements from JSON servlet.
- *
- * @return {google.visualization.DataTable} data the DataTable corresponding to
- *     the data on the number of undergraduate students per college
- */
-async function deserializeNumUndergradsData() {
-  const data = new google.visualization.DataTable();
-  await fetch('/viz/stats')
-      .then((response) => response.json())
-      .then(
-          (numUndergradsInfo) =>
-            populateNumUndergradsDataTable(data, numUndergradsInfo),
-      );
-  return data;
-}
-
-/**
- * Helper function to fetch elements from JSON servlet.
- *
- * @return {google.visualization.DataTable} data the DataTable corresponding to
- *     the gender ratio data
- */
-async function deserializeGenderRatioData() {
-  const data = new google.visualization.DataTable();
-  await fetch('/viz/stats')
-      .then((response) => response.json())
-      .then(
-          (genderRatioInfo) =>
-            populateGenderRatioDataTable(data, genderRatioInfo),
-      );
-  return data;
+      .then((data) => {
+        populateAdmissionRateDataTable(admissionRateDataTable, data);
+        populateNumUndergradsDataTable(numUndergradsDataTable, data);
+        populateAvgSatDataTable(avgSatDataTable, data);
+        populateGenderRatioDataTable(genderRatioDataTable, data);
+      }).then(() => {
+        admissionRateChart.draw(admissionRateDataTable, admissionRateOptions);
+        numUndergradsChart.draw(numUndergradsDataTable, numUndergradsOptions);
+        avgSatChart.draw(avgSatDataTable, avgSatOptions);
+        genderRatioChart.draw(genderRatioDataTable, genderRatioOptions);
+      });
 }
 
 /**

--- a/capstone/src/test/javascript/demographicalGraphsSpec.js
+++ b/capstone/src/test/javascript/demographicalGraphsSpec.js
@@ -18,13 +18,15 @@ describe('Demographical Data Table Construction', () => {
     },
   ];
   beforeEach(() => {
-    spyOn(window, 'fetch')
-        .and.returnValue(Promise.resolve({json: () => mockCollegeStatsInfo}));
     spyOn(google.visualization.DataTable.prototype, 'addRow');
     spyOn(google.visualization.DataTable.prototype, 'addColumn');
   });
   it('Will add correct columns/rows to Admission DataTable', async () => {
-    await deserializeAdmissionData();
+    const admissionRateDataTable = new google.visualization.DataTable();
+    populateAdmissionRateDataTable(
+        admissionRateDataTable,
+        mockCollegeStatsInfo,
+    );
     expect(google.visualization.DataTable.prototype.addRow)
         .toHaveBeenCalledWith([
           mockCollegeStatsInfo[0]['name'],
@@ -45,7 +47,8 @@ describe('Demographical Data Table Construction', () => {
         .toEqual(2);
   });
   it('Will add correct columns/rows to SAT score DataTable', async () => {
-    await deserializeAvgSatData();
+    const avgSatDataTable = new google.visualization.DataTable();
+    populateAvgSatDataTable(avgSatDataTable, mockCollegeStatsInfo);
     expect(google.visualization.DataTable.prototype.addRow)
         .toHaveBeenCalledWith([
           mockCollegeStatsInfo[0]['name'],
@@ -68,7 +71,11 @@ describe('Demographical Data Table Construction', () => {
   it(
       'Will add correct columns/rows to Number of Undergrads DataTable',
       async () => {
-        await deserializeNumUndergradsData();
+        const numUndergradsDataTable = new google.visualization.DataTable();
+        populateNumUndergradsDataTable(
+            numUndergradsDataTable,
+            mockCollegeStatsInfo,
+        );
         expect(google.visualization.DataTable.prototype.addRow)
             .toHaveBeenCalledWith([
               mockCollegeStatsInfo[0]['name'],
@@ -89,7 +96,8 @@ describe('Demographical Data Table Construction', () => {
             .toEqual(2);
       });
   it('Will add correct columns/rows to Gender Ratio DataTable', async () => {
-    await deserializeGenderRatioData();
+    const genderRatioDataTable = new google.visualization.DataTable();
+    populateGenderRatioDataTable(genderRatioDataTable, mockCollegeStatsInfo);
     expect(google.visualization.DataTable.prototype.addRow)
         .toHaveBeenCalledWith([
           mockCollegeStatsInfo[0]['name'],


### PR DESCRIPTION
Currently in `demographicalGraphs.js` the network resources are fetched repeatedly, and the graphs are drawn synchronously. This PR fetches from the network only once and draws the graphs concurrently.

Visual:
![image](https://user-images.githubusercontent.com/43079005/91333389-638a6380-e782-11ea-9fec-68d3df1e9ce0.png)