### PR TITLE
Instruments JaCoCo for coverage details

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -7,6 +7,25 @@
   <version>1.0-SNAPSHOT</version>
   <name>UniViz Maven Webapp</name>
   <url>http://maven.apache.org</url>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.5</version>
+        <configuration>
+          <excludes>
+            <!-- Exclude AutoValue generated classes. -->
+            <exclude>**/*_*.class</exclude>
+            <exclude>com/google/univiz/config/*.class</exclude>
+            <exclude>com/google/univiz/Grapher.class</exclude>
+            <exclude>com/google/univiz/*GuiceServletConfig*.class</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -132,6 +151,11 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.9.1</version>
       </plugin>
     </plugins>  
   </build>


### PR DESCRIPTION
Also brings maven site plugin up to date.

Coverage can be viewed after invoking `mvn site`:

![image](https://user-images.githubusercontent.com/2066940/91371750-be45ae80-e7c6-11ea-9d30-bb0edc26470e.png)
