### PR TITLE
Missing Properties in ScorecardData.java class

### DIFF
--- a/capstone/src/main/java/com/google/univiz/scorecard/ScorecardData.java
+++ b/capstone/src/main/java/com/google/univiz/scorecard/ScorecardData.java
@@ -83,7 +83,15 @@ abstract class ScorecardData {
   abstract double ratioOfWomen();
 
   static Builder builder() {
-    return new AutoValue_ScorecardData.Builder();
+    return new AutoValue_ScorecardData.Builder()
+        .setFlagMainCampus(0)
+        .setCarnegieSizeDegree(0)
+        .setAdmissionRate(0.0)
+        .setAvgSat(0.0)
+        .setNumOfUndergrads(0)
+        .setAvgCost(0)
+        .setRatioOfMen(0.0)
+        .setRatioOfWomen(0.0);
   }
 
   @AutoValue.Builder


### PR DESCRIPTION
This PR addresses the linked bug. When certain colleges are missing these properties, they will add these defaults. For now, this will suffice. In the future, we can think about addressing these values in the converters and thinking about what we send to the front-end through the servlet's JSON responses. 

Right now, these defaults will allow for the code to run for demo-ing purposes.